### PR TITLE
Clicking "deploy to bluemix" magic button will fail deployments with "host is taken"

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,4 @@
 ---
 applications:
 - name:    hello-node
-  host:    hello-node
   memory:  128M


### PR DESCRIPTION
Problem: the manifest.yml hard-coded host to `hello-node`. This will remain hard-coded even if you do `cf push ${APP_NAME}` in delivery pipeline.

The PR removes hard-coded host field from manifest.yml, so that cf push will deploy app using app name as hostname.
